### PR TITLE
Ensure Infracost uses the same TF version than Atlantis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ RUN \
   curl -s -L https://github.com/infracost/infracost/releases/latest/download/infracost-linux-amd64.tar.gz | tar xz -C /tmp && \
   mv /tmp/infracost-linux-amd64 /usr/bin/infracost && \
   # Fetch the atlantis_diff.sh script that runs infracost
-  curl -s -L -o /infracost_atlantis_diff.sh https://raw.githubusercontent.com/infracost/infracost/master/scripts/ci/atlantis_diff.sh && \
-  chmod +x /infracost_atlantis_diff.sh
+  curl -s -L -o /home/atlantis/infracost_atlantis_diff.sh https://raw.githubusercontent.com/infracost/infracost/master/scripts/ci/atlantis_diff.sh && \
+  chmod +x /home/atlantis/infracost_atlantis_diff.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN \
   mv /tmp/infracost-linux-amd64 /usr/bin/infracost && \
   # Fetch the atlantis_diff.sh script that runs infracost
   curl -s -L -o /home/atlantis/infracost_atlantis_diff.sh https://raw.githubusercontent.com/infracost/infracost/master/scripts/ci/atlantis_diff.sh && \
-  chmod +x /home/atlantis/infracost_atlantis_diff.sh
+  chmod +x /home/atlantis/infracost_atlantis_diff.sh && \
+  ln -s /home/atlantis/infracost_atlantis_diff.sh /infracost_atlantis_diff.sh

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This method runs `infracost diff` using the `$PLANFILE` that Atlantis generates.
                     }
                   },
                   {
-                    "run": "/infracost_atlantis_diff.sh"
+                    "run": "/home/atlantis/infracost_atlantis_diff.sh"
                   }
                 ]
               }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ This method runs `infracost diff` using the `$PLANFILE` that Atlantis generates.
                     }
                   },
                   {
+                    "env": {
+                      "name": "INFRACOST_TERRAFORM_BINARY",
+                      "command": "echo \"terraform${ATLANTIS_TERRAFORM_VERSION}\""
+                    }
+                  },
+                  {
                     "run": "/infracost_atlantis_diff.sh"
                   }
                 ]


### PR DESCRIPTION
Just a small improvement on the example so Infracosts always uses the same Terraform version that Atlantis is using to execute the Workflow.

I use the YAML config so I hope I haven't screwed up the JSON since I haven't tested it, it should be the equivalent of this:

```
        plan:
          steps:
          - init
          - plan
          - env:
              name: INFRACOST_TERRAFORM_BINARY
              command: 'echo "terraform${ATLANTIS_TERRAFORM_VERSION}"'
          - run: "/home/atlantis/infracost_atlantis_diff.sh || true"
```
Based on the Terragrunt example in the Atlantis docs: https://www.runatlantis.io/docs/custom-workflows.html#terragrunt


P.D: I had to change the path where I put the script on the container because in the example Dockerfile it's being copied on the root directory and I was having permission issues since the Atlantis container deployed with the official Helm chart runs as the atlantis user by default. 