### PR TITLE
Fix for vulnerability on jq-1.6-rc1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --update --no-cache add ca-certificates openssl openssh-client curl git
 # Reference: https://nvd.nist.gov/vuln/detail/CVE-2016-4074 (this is present on jq-1.6-rc1 as well)
 RUN \
     # Install jq-1.6 (final release)
-    curl -L -o /tmpjq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+    curl -s -L -o /tmp/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     mv /tmp/jq /usr/local/bin/jq && \
     chmod +x /usr/local/bin/jq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
-# Using latest release of Atlantis
 FROM runatlantis/atlantis:v0.16.1
 
 # Install required packages
-RUN apk --update --no-cache add ca-certificates openssl openssh-client curl git jq
+RUN apk --update --no-cache add ca-certificates openssl openssh-client curl git
+
+# The jq package provided by alpine:3.13 (jq 1.6-rc1) is flagged as a 
+# high severity vulnerability, so we install the latest release ourselves
+# Reference: https://nvd.nist.gov/vuln/detail/CVE-2016-4074 (this is present on jq-1.6-rc1 as well)
+RUN \
+    # Install jq-1.6 (final release)
+    curl -L -o /tmpjq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+    mv /tmp/jq /usr/local/bin/jq && \
+    chmod +x /usr/local/bin/jq
 
 RUN \
   # Install latest infracost version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Using latest release of Atlantis
 FROM runatlantis/atlantis:v0.16.1
 
 # Install required packages


### PR DESCRIPTION
The current base image being used by runatlantis/atlantis:v0.16.1 relies on alpine 3.13 (https://pkgs.alpinelinux.org/packages?name=jq&branch=v3.13), and it's `jq` version is flagged by CVE-2016-4074 (https://nvd.nist.gov/vuln/detail/CVE-2016-4074) with high severity. (7.5/10)

See result below from AWS' ECR image scanner run against the latest image from https://hub.docker.com/r/infracost/infracost-atlantis:

![image](https://user-images.githubusercontent.com/81971757/114086019-1de95980-9880-11eb-850b-7f1eb57d254f.png)

The finding is also being flagged by other scanning tools (https://github.com/quay/clair/issues/852)

With this PR, we no longer retrieve jq from alpine's repository; instead, we download the final 1.6 release from its official repository