### PR TITLE
Set Atlantis Docker tag

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "ATLANTIS_TAG=latest-atlantis$(cat Dockerfile | \
             grep -oE 'FROM.*atlantis.*' | \
-            grep -oE 'v?[0-9]+.[0-9]+.[0-9]+')" >> $GITHUB_ENV
+            grep -oE '[0-9]+.[0-9]+.[0-9]+')" >> $GITHUB_ENV
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v1


### PR DESCRIPTION
**What do you expect to happen?**
I think it would be nice if this project mirrored the Atlantis [releases](https://hub.docker.com/r/runatlantis/atlantis/tags).

**Why?**
Because this way, any update in the Atlantis version would provide the same tag for this Infracost "plugin"


Sorry I didn't open an Issue first. I saw [this one](https://github.com/infracost/infracost-atlantis/issues/10) wondering about versioning the plugin itself but it also made sense to me just mirroring the Atlantis. Plus my request seemed trivial to implement and I'm ready to face denial if my suggestion didn't match the expectations 🤷🏼
