### PR TITLE
Add monorepo GitHub comment example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,7 @@
 FROM runatlantis/atlantis:v0.17.5
 
 # Install required packages
-RUN apk --update --no-cache add ca-certificates openssl openssh-client curl git
-
-# The jq package provided by alpine:3.13 (jq 1.6-rc1) is flagged as a 
-# high severity vulnerability, so we install the latest release ourselves
-# Reference: https://nvd.nist.gov/vuln/detail/CVE-2016-4074 (this is present on jq-1.6-rc1 as well)
-RUN \
-    # Install jq-1.6 (final release)
-    curl -s -L -o /tmp/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-    mv /tmp/jq /usr/local/bin/jq && \
-    chmod +x /usr/local/bin/jq
+RUN apk --update --no-cache add ca-certificates openssl openssh-client curl git nodejs nodejs-npm
 
 RUN \
   # Install latest infracost version
@@ -21,3 +12,6 @@ RUN \
   curl -s -L -o /home/atlantis/infracost_atlantis_diff.sh https://raw.githubusercontent.com/infracost/infracost/master/scripts/ci/atlantis_diff.sh && \
   chmod +x /home/atlantis/infracost_atlantis_diff.sh && \
   ln -s /home/atlantis/infracost_atlantis_diff.sh /infracost_atlantis_diff.sh
+
+# Install the latest compost version
+RUN npm install -g @infracost/compost

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM runatlantis/atlantis:v0.17.5
 
 # Install required packages
-RUN apk --update --no-cache add ca-certificates openssl openssh-client curl git nodejs nodejs-npm
+RUN apk --update --no-cache add ca-certificates openssl openssh-client curl git jq nodejs nodejs-npm
 
 RUN \
   # Install latest infracost version

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Examples
+
+* [Post a GitHub PR comment for a Terraform mono-repo](monorepo_github_comment.yml) - This example shows how to use [compost](https://github.com/infracost/compost) with Atlantis and Infracost to post a comment with the Infracost result. This uses a pre-workflow hook to create a placeholder comment, which is then updated with the results as the workflow runs. The behavior of the comment can be changed by changing the `hide-and-new` argument in the pre-workflow hook.

--- a/examples/monorepo_github_comment.yml
+++ b/examples/monorepo_github_comment.yml
@@ -1,0 +1,35 @@
+# This example shows how to use compost with Atlantis and Infracost to post a comment with the Infracost result.
+# This uses a pre-workflow hook to create a placeholder comment, which is then updated with the results as the workflow runs.
+# The behavior of the comment can be changed by changing the 'hide-and-new' argument in the pre-workflow hook.
+# 
+# To run this:
+# export GITHUB_TOKEN=<your-github-token>
+# export INFRACOST_API_KEY=<your-infracost-api-token>
+# docker run -p 4141:4141 -e GITHUB_TOKEN=$GITHUB_TOKEN -e INFRACOST_API_KEY=$INFRACOST_API_KEY \
+#   --mount type=bind,source=$(pwd)/examples/monorepo_github_comment.yml,target=/home/atlantis/repo.yml \
+#   infracost/infracost-atlantis:compost-test server \
+#   --gh-user=<your-github-user> \
+#   --gh-token=$GITHUB_TOKEN \
+#   --gh-webhook-secret=<your-github-webhook-secret> \
+#   --repo-allowlist='github.com/your-org/*' --repo-config=/home/atlantis/repo.yml
+repos:
+  - id: /.*/
+    workflow: terraform-infracost
+    pre_workflow_hooks:
+      # Clean up any files left over from the last run
+      - run: rm -r /tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM-*.*
+      # Create placeholder comment that is updated during the workflow
+      # The behavior can be 'update', 'new', 'hide-and-new', 'delete-and-new'
+      - run: compost github hide-and-new $BASE_REPO_OWNER/$BASE_REPO_NAME pr $PULL_NUM --body="This comment will be updated with the Infracost estimate."
+workflows:
+  terraform-infracost:
+    plan:
+      steps:
+        - init
+        - plan
+        # Run Infracost breakdown and save to a tempfile, namespaced by this project, PR, workspace and dir
+        - run: infracost breakdown --path=$PLANFILE --format=json --log-level=info --out-file=/tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM-$WORKSPACE-$REPO_REL_DIR-infracost.json
+        # Generate a comment for all the breakdowns for this workflow. This uses a wildcard so will get updated as more workspaces/dirs run
+        - run: infracost output --path=/tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM-*-infracost.json --format=github-comment --out-file=/tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM-infracost-comment.md
+        # Use compost to update the placeholder comment with a comment containing the results for all runs so far for this workflow
+        - run: compost github update $BASE_REPO_OWNER/$BASE_REPO_NAME pr $PULL_NUM --github-token $GITHUB_TOKEN --body-file=/tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM-infracost-comment.md


### PR DESCRIPTION
This adds an example of how to post a GitHub comment when using Atlantis with a monorepo Terraform project.

This installs [compost](https://github.com/infracost/compost) in the Dockerfile (currently pushed at `infracost/infracost-atlantis:compost-test`), and uses it to post an Infracost GitHub comment on pull requests.