### PR TITLE
chore: Update create-release GitHub workflow to use 2 last minor Atlantis releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,27 +1,61 @@
-name: Create release assets
+name: Create Atlantis release
 
-on:
-  push:
-    branches: [ master ]
+on: workflow_dispatch
 
 jobs:
-  build:
-    name: Create release assets
+  generate-release-matrix:
+    name: Generate release matrix
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        name: Set matrix
+        shell: bash
+        run: |
+          cli=$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -s https://api.github.com/repos/infracost/infracost/releases | jq -r '.[0].tag_name | capture("^v(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)") | {cli_version: "\(.major).\(.minor).\(.patch)", cli_release: "\(.major).\(.minor)"} | tostring')
+          atlantis=$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -s https://api.github.com/repos/runatlantis/atlantis/releases\?per_page\=100 | jq -r '[.[].tag_name] | map(capture("^v(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)")) | map({version: "\(.major).\(.minor).\(.patch)", group: "\(.major).\(.minor)", major: .major | tonumber, minor: .minor | tonumber, patch:  .patch | tonumber}) | group_by(.group) | map (.[0]) | sort_by(.major, .minor, .patch) | reverse | .[:2] | . as $result | map({atlantis_version: .version, atlantis_release: .group, latest: (.version == $result[0].version)}) | tostring')
+          matrix=$(jq --argjson atlantis $atlantis --argjson cli $cli -n -c '$atlantis | map(. + $cli) | {include: .}')
+          echo $matrix
+          echo "::set-output name=matrix::$matrix"
+  build:
+    name: Create release for Atlantis ${{ matrix.atlantis_version}}, Infracost ${{ matrix.cli_version }}
+    needs: generate-release-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{fromJson(needs.generate-release-matrix.outputs.matrix)}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set Atlantis docker tag
-        run: |
-          echo "ATLANTIS_TAG=latest-atlantis$(cat Dockerfile | \
-            grep -oE 'FROM.*atlantis.*' | \
-            grep -oE '[0-9]+.[0-9]+.[0-9]+')" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ secrets.DOCKER_ORG }}/${{ secrets.DOCKER_REPOSITORY }}
-          tags: ${{ env.ATLANTIS_TAG }},latest
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: infracost/infracost-atlantis
+          flavor: |
+            latest=${{ matrix.latest }}
+          tags: |
+            type=raw,value=atlantis${{ matrix.atlantis_release }}-infracost${{ matrix.cli_release }}
+          labels: |
+            atlantis-version=${{ matrix.atlantis_version }}
+            cli-version=${{ matrix.cli_version }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            version=v${{ matrix.atlantis_version }}
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
+ARG version
 # Using latest release of Atlantis
-FROM ghcr.io/runatlantis/atlantis:v0.18.1
+FROM ghcr.io/runatlantis/atlantis:${version}
 
 # Install required packages
 RUN apk --update --no-cache add ca-certificates openssl openssh-client curl git jq nodejs npm


### PR DESCRIPTION
Tested on `infracost/atlantis-test` images: https://hub.docker.com/u/infracost