### PR TITLE
chore: update base image to 0.18.5

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Using latest release of Atlantis
-FROM ghcr.io/runatlantis/atlantis:v0.18.4
+FROM ghcr.io/runatlantis/atlantis:v0.18.5
 
 # Copy the built local binary of infracost - note this needs to happen before running docker-compose up
 ADD infracost /usr/local/bin/infracost


### PR DESCRIPTION
Emergency update due to a bug found with 0.18.4 (https://github.com/runatlantis/atlantis/issues/2104)

relates to https://github.com/runatlantis/atlantis/pull/2107