### PR TITLE
chore: update atlantis to 0.19.0

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Using latest release of Atlantis
-FROM ghcr.io/runatlantis/atlantis:v0.18.5
+FROM ghcr.io/runatlantis/atlantis:v0.19.0
 
 # Copy the built local binary of infracost - note this needs to happen before running docker-compose up
 ADD infracost /usr/local/bin/infracost


### PR DESCRIPTION
relates to runatlantis/atlantis#2115

---

0.19.0 has multi-arch docker image support