### PR TITLE
Update examples with project name using REPO_REL_DIR Atlantis variable

### DIFF
--- a/examples/append-to-atlantis-comments/README.md
+++ b/examples/append-to-atlantis-comments/README.md
@@ -44,7 +44,7 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. The 
                 infracost breakdown --path=$SHOWFILE \
                                     --format=json \
                                     --log-level=info \
-                                    --out-file=$INFRACOST_OUTPUT
+                                    --out-file=$INFRACOST_OUTPUT \
                                     --project-name=$REPO_REL_DIR
             - run: |
                 # Read the breakdown JSON and get costs using jq.

--- a/examples/append-to-atlantis-comments/README.md
+++ b/examples/append-to-atlantis-comments/README.md
@@ -11,10 +11,13 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. The 
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 
 4. You'll need to pass the following custom env var into the container.
+
    ```sh
    INFRACOST_API_KEY=<your-infracost-api-token>
    ```
+
 5. Add the following yaml spec to `repos.yaml` or `atlantis.yaml` config files:
+
     ```yaml
     repos:
       - id: /.*/
@@ -31,7 +34,7 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. The 
                 command: 'echo "/tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM-$WORKSPACE-${REPO_REL_DIR//\//-}-infracost.json"'
             # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
             #   complements the open source CLI by giving teams advanced visibility and controls.
-            #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+            #   The cost estimates are transmitted in JSON format and do not contain any cloud
             #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
             - env:
                 name: INFRACOST_ENABLE_CLOUD
@@ -42,6 +45,7 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. The 
                                     --format=json \
                                     --log-level=info \
                                     --out-file=$INFRACOST_OUTPUT
+                                    --project-name=$REPO_REL_DIR
             - run: |
                 # Read the breakdown JSON and get costs using jq.
                 # Note jq comes as standard as part of infracost-atlantis Docker images. If you are using the base atlantis
@@ -147,6 +151,7 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. The 
 
                 printf "$msg"
     ```
+
 6. Restart the Atlantis application with the new environment vars and config
 7. Send a pull request to change something in the Terraform code, the Infracost output should be added to your Atlantis comment.
 

--- a/examples/combined-infracost-comment/README.md
+++ b/examples/combined-infracost-comment/README.md
@@ -16,16 +16,18 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
 
 ## Running with GitHub
 
-
 1. Update your setup to use the [infracost-atlantis](https://hub.docker.com/r/infracost/infracost-atlantis) Docker image
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env var into the container.
+
   ```sh
   GITHUB_TOKEN=<your-github-token>
   INFRACOST_API_KEY=<your-infracost-api-token>
   ```
+
 5. Add the following yaml spec to `repos.yaml` or `atlantis.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -33,11 +35,11 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
       post_workflow_hooks:
         # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
         #   complements the open source CLI by giving teams advanced visibility and controls.
-        #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+        #   The cost estimates are transmitted in JSON format and do not contain any cloud
         #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
         - env:
             name: INFRACOST_ENABLE_CLOUD
-            value: true 
+            value: true
         - run: |
             # post_workflow_hooks are executed after the repo workflow has run.
             # This enables you to post an Infracost comment with the combined cost output
@@ -71,7 +73,7 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
               command: 'echo "/tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM/$WORKSPACE-${REPO_REL_DIR//\//-}-infracost.json"'
           # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
           #   complements the open source CLI by giving teams advanced visibility and controls.
-          #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+          #   The cost estimates are transmitted in JSON format and do not contain any cloud
           #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
           - env:
               name: INFRACOST_ENABLE_CLOUD
@@ -89,7 +91,9 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
                                   --format=json \
                                   --log-level=info \
                                   --out-file=$INFRACOST_OUTPUT
+                                  --project-name=$REPO_REL_DIR
   ```
+
 6. Restart the Atlantis application with the new environment vars and config.
 7. Send a pull request in GitHub to change something in the Terraform code, the Infracost pull request comment should be added and show details for every changed project.
 
@@ -105,11 +109,14 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env var into the container.
+
   ```sh
   GITLAB_TOKEN=<your-gitlab-token>
   INFRACOST_API_KEY=<your-infracost-api-token>
   ```
+
 5. Add the following yaml spec to `repos.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -121,7 +128,7 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
       post_workflow_hooks:
         # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
         #   complements the open source CLI by giving teams advanced visibility and controls.
-        #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+        #   The cost estimates are transmitted in JSON format and do not contain any cloud
         #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
         - env:
             name: INFRACOST_ENABLE_CLOUD
@@ -148,8 +155,9 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
           - plan
           - show # this writes the plan JSON to $SHOWFILE
           # Run Infracost breakdown and save to a tempfile, namespaced by this project, PR, workspace and dir
-          - run: infracost breakdown --path=$SHOWFILE --format=json --log-level=info --out-file=$INFRACOST_OUTPUT
+          - run: infracost breakdown --path=$SHOWFILE --format=json --log-level=info --out-file=$INFRACOST_OUTPUT --project-name=$REPO_REL_DIR
   ```
+
 6. Restart the Atlantis application with the new environment vars and config.
 7. Send a merge request in GitLab to change something in the Terraform code, the Infracost merge request comment should be added and show details for every changed project.
 
@@ -165,12 +173,15 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env vars into the container. Retrieve your Infracost API key by running `infracost configure get api_key`. We recommend using your same API key in all environments. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
+
   ```sh
   AZURE_ACCESS_TOKEN=<your-azure-devops-access-token-or-pat>
   AZURE_REPO_URL=<your-azure-repo-url> # i.e., https://dev.azure.com/your-org/your-project/_git/your-repo
   INFRACOST_API_KEY=<your-infracost-api-token>
   ```
+
 3. Add the following yaml spec to `repos.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -182,7 +193,7 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
       post_workflow_hooks:
         # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
         #   complements the open source CLI by giving teams advanced visibility and controls.
-        #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+        #   The cost estimates are transmitted in JSON format and do not contain any cloud
         #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
         - env:
             name: INFRACOST_ENABLE_CLOUD
@@ -210,8 +221,9 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
           - plan
           - show # this writes the plan JSON to $SHOWFILE
           # Run Infracost breakdown and save to a tempfile, namespaced by this project, PR, workspace and dir
-          - run: infracost breakdown --path=$SHOWFILE --format=json --log-level=info --out-file=$INFRACOST_OUTPUT
+          - run: infracost breakdown --path=$SHOWFILE --format=json --log-level=info --out-file=$INFRACOST_OUTPUT --project-name=$REPO_REL_DIR
   ```
+
 6. Restart the Atlantis application with the new environment vars and config.
 7. Send a pull request in Azure Repos to change something in the Terraform code, the Infracost merge request comment should be added and show details for every changed project.
 
@@ -227,11 +239,14 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env vars into the container. Retrieve your Infracost API key by running `infracost configure get api_key`. We recommend using your same API key in all environments. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
+
   ```sh
   BITBUCKET_TOKEN=<your-bitbucket-token> # for Bitbucket Cloud this should be username:token, where the token can be a user or App password. For Bitbucket Server provide only an HTTP access token.
   INFRACOST_API_KEY=<your-infracost-api-token>
   ```
+
 5. Add the following yaml spec to `repos.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -239,11 +254,11 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
       pre_workflow_hooks:
         # Clean up any files left over from previous runs
         - run: rm -rf /tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM
-        - run: mkdir -p /tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM      
+        - run: mkdir -p /tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM
       post_workflow_hooks:
         # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
         #   complements the open source CLI by giving teams advanced visibility and controls.
-        #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+        #   The cost estimates are transmitted in JSON format and do not contain any cloud
         #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
         - env:
             name: INFRACOST_ENABLE_CLOUD
@@ -292,7 +307,9 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
                                   --format=json \
                                   --log-level=info \
                                   --out-file=$INFRACOST_OUTPUT
+                                  --project-name=$REPO_REL_DIR
   ```
+
 6. Restart the Atlantis application with the new environment vars and config.
 7. Send a pull request in Bitbucket to change something in the Terraform code, the Infracost pull request comment should be added and show details for every changed project.
 

--- a/examples/combined-infracost-comment/README.md
+++ b/examples/combined-infracost-comment/README.md
@@ -306,7 +306,7 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
               infracost breakdown --path=$SHOWFILE \
                                   --format=json \
                                   --log-level=info \
-                                  --out-file=$INFRACOST_OUTPUT
+                                  --out-file=$INFRACOST_OUTPUT \
                                   --project-name=$REPO_REL_DIR
   ```
 

--- a/examples/combined-infracost-comment/README.md
+++ b/examples/combined-infracost-comment/README.md
@@ -90,7 +90,7 @@ This Atlantis repo.yaml file shows how Infracost can be used with Atlantis. Even
               infracost breakdown --path=$SHOWFILE \
                                   --format=json \
                                   --log-level=info \
-                                  --out-file=$INFRACOST_OUTPUT
+                                  --out-file=$INFRACOST_OUTPUT \
                                   --project-name=$REPO_REL_DIR
   ```
 

--- a/examples/conftest/README.md
+++ b/examples/conftest/README.md
@@ -13,6 +13,7 @@ This example shows how to use [Atlantis' built-in Conftest](https://www.runatlan
 ## Configuration
 
 1. Add the YAML contents of this file to your `repos.yaml` or `atlantis.yaml` server side config file:
+
   ```yaml
   repos:
     - id: /.*/
@@ -32,6 +33,7 @@ This example shows how to use [Atlantis' built-in Conftest](https://www.runatlan
                                   --out-file=$INFRACOST_OUTPUT \
                                   --log-level=warn \
                                   --no-color
+                                  --project-name=$REPO_REL_DIR
           - policy_check:
               extra_args: [ "-p /home/atlantis/policy", "--namespace", "infracost", "$INFRACOST_OUTPUT" ]
   policies:
@@ -43,7 +45,9 @@ This example shows how to use [Atlantis' built-in Conftest](https://www.runatlan
         path: /home/atlantis/policy
         source: local
   ```
+
 2. Create a policy file in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/) `policy.rego` and make it available at `/home/atlantis/policy`:
+
   ```rego
   package infracost
 
@@ -88,7 +92,9 @@ This example shows how to use [Atlantis' built-in Conftest](https://www.runatlan
           )
   }
   ```
+
 3. On the Atlantis server, export env vars for the following. Retrieve your Infracost API key by running `infracost configure get api_key`. We recommend using your same API key in all environments. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
+
   ```
   export INFRACOST_API_KEY=<your-infracost-api-token>
   ```
@@ -96,6 +102,7 @@ This example shows how to use [Atlantis' built-in Conftest](https://www.runatlan
 ## Running with GitHub
 
 1. Run the `infracost/infracost-atlantis` image, which includes the Infracost CLI in addition to Atlantis:
+
   ```
   docker run -p 4141:4141 -e INFRACOST_API_KEY=$INFRACOST_API_KEY \
     --mount type=bind,source=$(pwd)/examples/conftest/conftest.yml,target=/home/atlantis/repo.yml \
@@ -108,12 +115,14 @@ This example shows how to use [Atlantis' built-in Conftest](https://www.runatlan
     --repo-config=/home/atlantis/repo.yml \
     --enable-policy-checks
   ```
+
 2. Send a pull request in GitHub to change something in Terraform, note the policy checks are performed.
 3. Experiment with different cost policies by editing `policy.rego`.
 
 ## Running with GitLab
 
 1. Run the `infracost/infracost-atlantis` image, which includes the Infracost CLI in addition to Atlantis:
+
   ```
   docker run -p 4141:4141 -e INFRACOST_API_KEY=$INFRACOST_API_KEY \
     --mount type=bind,source=$(pwd)/examples/conftest/conftest.yml,target=/home/atlantis/repo.yml \
@@ -126,12 +135,14 @@ This example shows how to use [Atlantis' built-in Conftest](https://www.runatlan
     --repo-config=/home/atlantis/repo.yml \
     --enable-policy-checks
   ```
+
 2. Send a merge request in GitLab to change something in Terraform, note the policy checks are performed.
 3. Experiment with different cost policies by editing `policy.rego`.
 
 ## Running with Azure Repos
 
 1. Run the `infracost/infracost-atlantis` image, which includes the Infracost CLI in addition to Atlantis:
+
   ```
   docker run -p 4141:4141 -e INFRACOST_API_KEY=$INFRACOST_API_KEY \
     --mount type=bind,source=$(pwd)/examples/conftest/conftest.yml,target=/home/atlantis/repo.yml \
@@ -145,6 +156,7 @@ This example shows how to use [Atlantis' built-in Conftest](https://www.runatlan
     --repo-config=/home/atlantis/repo.yml \
     --enable-policy-checks
   ```
+
 2. Send a merge request in GitLab to change something in Terraform, note the policy checks are performed.
 3. Experiment with different cost policies by editing `policy.rego`.
 

--- a/examples/conftest/README.md
+++ b/examples/conftest/README.md
@@ -32,7 +32,7 @@ This example shows how to use [Atlantis' built-in Conftest](https://www.runatlan
                                   --format=json \
                                   --out-file=$INFRACOST_OUTPUT \
                                   --log-level=warn \
-                                  --no-color
+                                  --no-color \
                                   --project-name=$REPO_REL_DIR
           - policy_check:
               extra_args: [ "-p /home/atlantis/policy", "--namespace", "infracost", "$INFRACOST_OUTPUT" ]

--- a/examples/conftest/conftest.yml
+++ b/examples/conftest/conftest.yml
@@ -36,8 +36,15 @@ workflows:
                                 --out-file=$INFRACOST_OUTPUT \
                                 --log-level=warn \
                                 --no-color
+                                --project-name=$REPO_REL_DIR
         - policy_check:
-            extra_args: [ "-p /home/atlantis/policy", "--namespace", "infracost", "$INFRACOST_OUTPUT" ]
+            extra_args:
+              [
+                "-p /home/atlantis/policy",
+                "--namespace",
+                "infracost",
+                "$INFRACOST_OUTPUT",
+              ]
 policies:
   owners:
     users:

--- a/examples/multiple-infracost-comments/README.md
+++ b/examples/multiple-infracost-comments/README.md
@@ -186,7 +186,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               infracost breakdown --path=$SHOWFILE \
                                   --format=json \
                                   --log-level=info \
-                                  --out-file=$INFRACOST_OUTPUT
+                                  --out-file=$INFRACOST_OUTPUT \
                                   --project-name=$REPO_REL_DIR
           - run: |
             # Choose the commenting behavior, 'new' is a good default:

--- a/examples/multiple-infracost-comments/README.md
+++ b/examples/multiple-infracost-comments/README.md
@@ -18,11 +18,14 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env vars into the container. Retrieve your Infracost API key by running `infracost configure get api_key`. We recommend using your same API key in all environments. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
+
   ```sh
   GITHUB_TOKEN=<your-github-token>
   INFRACOST_API_KEY=<your-infracost-api-token>
   ```
+
 5. Add the following YAML spec to `repos.yaml` or `atlantis.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -46,6 +49,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                   --format=json \
                                   --log-level=info \
                                   --out-file=$INFRACOST_OUTPUT
+                                  --project-name=$REPO_REL_DIR
           - run: |
               # Choose the commenting behavior, 'new' is a good default:
               #   new: Create a new cost estimate comment on every run of Atlantis for each project.
@@ -62,6 +66,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                        --tag $INFRACOST_COMMENT_TAG \
                                        --behavior new
   ```
+
 6. Restart the Atlantis application with the new environment vars and config.
 7. Send a pull request in GitHub to change something in the Terraform code, the Infracost pull request comment should be added.
 8. To see the test pull request costs in Infracost Cloud, [log in](https://dashboard.infracost.io/) > switch to your organization > Projects. To learn more, see [our docs](https://www.infracost.io/docs/infracost_cloud/get_started/).
@@ -75,11 +80,14 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env vars into the container. Retrieve your Infracost API key by running `infracost configure get api_key`. We recommend using your same API key in all environments. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
+
   ```sh
   GITLAB_TOKEN=<your-gitlab-token>
   INFRACOST_API_KEY=<your-infracost-api-token>
   ```
+
 5. Add the following YAML spec to `repos.yaml` or `atlantis.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -96,11 +104,11 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               command: 'echo "$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM-$WORKSPACE-${REPO_REL_DIR//\//-}"'
           # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
           #   complements the open source CLI by giving teams advanced visibility and controls.
-          #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+          #   The cost estimates are transmitted in JSON format and do not contain any cloud
           #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
           - env:
               name: INFRACOST_ENABLE_CLOUD
-              value: true              
+              value: true
           - init
           - plan
           - show # this writes the plan JSON to $SHOWFILE
@@ -110,6 +118,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                   --format=json \
                                   --log-level=info \
                                   --out-file=$INFRACOST_OUTPUT
+                                  --project-name=$REPO_REL_DIR
           - run: |
               # Choose the commenting behavior, 'new' is a good default:
               #   new: Create a new cost estimate comment on every run of Atlantis for each project.
@@ -117,7 +126,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               #   delete-and-new: Delete previous comments and create a new one.
               # You can use `tag` to customize the hidden markdown tag used to detect comments posted by Infracost. We pass in the project directory here
               # so that there are no conflicts across projects when posting to the pull request. This is especially important if you
-              # use a comment behavior other than "new".              
+              # use a comment behavior other than "new".
               infracost comment gitlab --repo $BASE_REPO_OWNER/$BASE_REPO_NAME \
                                        --merge-request $PULL_NUM \
                                        --path $INFRACOST_OUTPUT \
@@ -125,6 +134,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                        --tag $INFRACOST_COMMENT_TAG \
                                        --behavior new
   ```
+
 6. Restart the Atlantis application with the new environment vars and config.
 7. Send a merge request in GitLab to change something in the Terraform code, the Infracost merge request comment should be added.
 8. To see the test pull request costs in Infracost Cloud, [log in](https://dashboard.infracost.io/) > switch to your organization > Projects. To learn more, see [our docs](https://www.infracost.io/docs/infracost_cloud/get_started/).
@@ -138,12 +148,15 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env vars into the container. Retrieve your Infracost API key by running `infracost configure get api_key`. We recommend using your same API key in all environments. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
+
   ```sh
   AZURE_ACCESS_TOKEN=<your-azure-devops-access-token-or-pat>
   AZURE_REPO_URL=<your-azure-repo-url> # i.e., https://dev.azure.com/your-org/your-project/_git/your-repo
   INFRACOST_API_KEY=<your-infracost-api-token>
   ```
+
 5. Add the following YAML spec to `repos.yaml` or `atlantis.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -160,7 +173,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               command: 'echo "${BASE_REPO_OWNER//\//-}-$BASE_REPO_NAME-$PULL_NUM-$WORKSPACE-${REPO_REL_DIR//\//-}"'
           # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
           #   complements the open source CLI by giving teams advanced visibility and controls.
-          #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+          #   The cost estimates are transmitted in JSON format and do not contain any cloud
           #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
           - env:
               name: INFRACOST_ENABLE_CLOUD
@@ -174,6 +187,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                   --format=json \
                                   --log-level=info \
                                   --out-file=$INFRACOST_OUTPUT
+                                  --project-name=$REPO_REL_DIR
           - run: |
             # Choose the commenting behavior, 'new' is a good default:
             #   new: Create a new cost estimate comment on every run of Atlantis for each project.

--- a/examples/multiple-infracost-comments/README.md
+++ b/examples/multiple-infracost-comments/README.md
@@ -117,7 +117,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               infracost breakdown --path=$SHOWFILE \
                                   --format=json \
                                   --log-level=info \
-                                  --out-file=$INFRACOST_OUTPUT
+                                  --out-file=$INFRACOST_OUTPUT \
                                   --project-name=$REPO_REL_DIR
           - run: |
               # Choose the commenting behavior, 'new' is a good default:

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -56,7 +56,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               infracost breakdown --path=$SHOWFILE \
                                   --format=json \
                                   --log-level=info \
-                                  --out-file=$INFRACOST_OUTPUT
+                                  --out-file=$INFRACOST_OUTPUT \
                                   --project-name=$REPO_REL_DIR
           # Use Infracost comment to create a comment containing the results for this project
           - run: |

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -141,7 +141,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               infracost breakdown --path=$SHOWFILE \
                                   --format=json \
                                   --log-level=info \
-                                  --out-file=$INFRACOST_OUTPUT
+                                  --out-file=$INFRACOST_OUTPUT \
                                   --project-name=$REPO_REL_DIR
           # Use Infracost comment to create a comment containing the results for this project
           - run: |

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -227,7 +227,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               infracost breakdown --path=$SHOWFILE \
                                   --format=json \
                                   --log-level=info \
-                                  --out-file=$INFRACOST_OUTPUT
+                                  --out-file=$INFRACOST_OUTPUT \
                                   --project-name=$REPO_REL_DIR
           # Use Infracost comment to create a comment containing the results for this project
           - run: |

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -18,12 +18,15 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env vars into the container. Retrieve your Infracost API key by running `infracost configure get api_key`. We recommend using your same API key in all environments. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
+
   ```sh
   GITHUB_TOKEN=<your-github-token>
   INFRACOST_API_KEY=<your-infracost-api-token>
   SLACK_WEBHOOK_URL: <your-slack-webhook-url>
   ```
+
 5. Add the following YAML spec to `repos.yaml` or `atlantis.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -40,7 +43,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               command: 'echo "/tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM-$WORKSPACE-${REPO_REL_DIR//\//-}-slack-message.json"'
           # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
           #   complements the open source CLI by giving teams advanced visibility and controls.
-          #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+          #   The cost estimates are transmitted in JSON format and do not contain any cloud
           #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
           - env:
               name: INFRACOST_ENABLE_CLOUD
@@ -54,6 +57,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                   --format=json \
                                   --log-level=info \
                                   --out-file=$INFRACOST_OUTPUT
+                                  --project-name=$REPO_REL_DIR
           # Use Infracost comment to create a comment containing the results for this project
           - run: |
               infracost comment github --repo $BASE_REPO_OWNER/$BASE_REPO_NAME \
@@ -85,6 +89,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
 
               curl -X POST -H "Content-type: application/json" -d @$INFRACOST_SLACK_MESSAGE $SLACK_WEBHOOK_URL
   ```
+
 6. Restart the Atlantis application with the new environment vars and config.
 7. Send a pull request in GitHub to change something in the Terraform code, the Infracost pull request comment will be added and a Slack message will be posted if there is cost change.
 8. To see the test pull request costs in Infracost Cloud, [log in](https://dashboard.infracost.io/) > switch to your organization > Projects. To learn more, see [our docs](https://www.infracost.io/docs/infracost_cloud/get_started/).
@@ -98,12 +103,15 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env vars into the container. Retrieve your Infracost API key by running `infracost configure get api_key`. We recommend using your same API key in all environments. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
+
   ```sh
   GITLAB_TOKEN=<your-gitlab-token>
   INFRACOST_API_KEY=<your-infracost-api-token>
   SLACK_WEBHOOK_URL: <your-slack-webhook-url>
   ```
+
 5. Add the following YAML spec to `repos.yaml` or `atlantis.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -120,7 +128,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               command: 'echo "/tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM-$WORKSPACE-${REPO_REL_DIR//\//-}-slack-message.json"'
           # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
           #   complements the open source CLI by giving teams advanced visibility and controls.
-          #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+          #   The cost estimates are transmitted in JSON format and do not contain any cloud
           #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
           - env:
               name: INFRACOST_ENABLE_CLOUD
@@ -134,6 +142,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                   --format=json \
                                   --log-level=info \
                                   --out-file=$INFRACOST_OUTPUT
+                                  --project-name=$REPO_REL_DIR
           # Use Infracost comment to create a comment containing the results for this project
           - run: |
               infracost comment gitlab --repo $BASE_REPO_OWNER/$BASE_REPO_NAME \
@@ -165,6 +174,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
 
               curl -X POST -H "Content-type: application/json" -d @$INFRACOST_SLACK_MESSAGE $SLACK_WEBHOOK_URL
   ```
+
 6. Restart the Atlantis application with the new environment vars and config.
 7. Send a merge request in GitLab to change something in the Terraform code, the Infracost merge request comment will be added and a Slack message will be posted if there is cost change.
 8. To see the test pull request costs in Infracost Cloud, [log in](https://dashboard.infracost.io/) > switch to your organization > Projects. To learn more, see [our docs](https://www.infracost.io/docs/infracost_cloud/get_started/).
@@ -178,13 +188,16 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env vars into the container. Retrieve your Infracost API key by running `infracost configure get api_key`. We recommend using your same API key in all environments. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
+
   ```sh
   AZURE_ACCESS_TOKEN=<your-azure-devops-access-token-or-pat>
   AZURE_REPO_URL=<your-azure-repo-url> # i.e., https://dev.azure.com/your-org/your-project/_git/your-repo
   INFRACOST_API_KEY=<your-infracost-api-token>
   SLACK_WEBHOOK_URL: <your-slack-webhook-url>
   ```
+
 5. Add the following YAML spec to `repos.yaml` or `atlantis.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -201,7 +214,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               command: 'echo "/tmp/${BASE_REPO_OWNER//\//-}-$BASE_REPO_NAME-$PULL_NUM-$WORKSPACE-${REPO_REL_DIR//\//-}-slack-message.json"'
           # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
           #   complements the open source CLI by giving teams advanced visibility and controls.
-          #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+          #   The cost estimates are transmitted in JSON format and do not contain any cloud
           #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
           - env:
               name: INFRACOST_ENABLE_CLOUD
@@ -215,6 +228,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                   --format=json \
                                   --log-level=info \
                                   --out-file=$INFRACOST_OUTPUT
+                                  --project-name=$REPO_REL_DIR
           # Use Infracost comment to create a comment containing the results for this project
           - run: |
               infracost comment azure-repos --repo-url $AZURE_REPO_URL \

--- a/examples/thresholds/README.md
+++ b/examples/thresholds/README.md
@@ -138,7 +138,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               infracost breakdown --path=$SHOWFILE \
                                   --format=json \
                                   --log-level=info \
-                                  --out-file=$INFRACOST_OUTPUT
+                                  --out-file=$INFRACOST_OUTPUT \
                                   --project-name=$REPO_REL_DIR
           - run: |
               # Read the breakdown JSON and get costs using jq.

--- a/examples/thresholds/README.md
+++ b/examples/thresholds/README.md
@@ -227,7 +227,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               infracost breakdown --path=$SHOWFILE \
                                   --format=json \
                                   --log-level=info \
-                                  --out-file=$INFRACOST_OUTPUT
+                                  --out-file=$INFRACOST_OUTPUT \
                                   --project-name=$REPO_REL_DIR
           - run: |
               # Read the breakdown JSON and get costs using jq.

--- a/examples/thresholds/README.md
+++ b/examples/thresholds/README.md
@@ -50,7 +50,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               infracost breakdown --path=$SHOWFILE \
                                   --format=json \
                                   --log-level=info \
-                                  --out-file=$INFRACOST_OUTPUT
+                                  --out-file=$INFRACOST_OUTPUT \
                                   --project-name=$REPO_REL_DIR
           - run: |
               # Read the breakdown JSON and get costs using jq.

--- a/examples/thresholds/README.md
+++ b/examples/thresholds/README.md
@@ -16,11 +16,14 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env vars into the container. Retrieve your Infracost API key by running `infracost configure get api_key`. We recommend using your same API key in all environments. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
+
   ```sh
   GITHUB_TOKEN=<your-github-token>
   INFRACOST_API_KEY=<your-infracost-api-token>
   ```
+
 5. Add the following YAML spec to `repos.yaml` or `atlantis.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -34,7 +37,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               command: 'echo "/tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM-$WORKSPACE-${REPO_REL_DIR//\//-}-infracost.json"'
           # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
           #   complements the open source CLI by giving teams advanced visibility and controls.
-          #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+          #   The cost estimates are transmitted in JSON format and do not contain any cloud
           #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
           - env:
               name: INFRACOST_ENABLE_CLOUD
@@ -48,6 +51,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                   --format=json \
                                   --log-level=info \
                                   --out-file=$INFRACOST_OUTPUT
+                                  --project-name=$REPO_REL_DIR
           - run: |
               # Read the breakdown JSON and get costs using jq.
               # Note jq comes as standard as part of the infracost-atlantis Docker image. If you are using the base Atlantis
@@ -86,6 +90,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                        --github-token $GITHUB_TOKEN \
                                        --behavior new
   ```
+
 6. Restart the Atlantis application with the new environment vars and config.
 7. Send a pull request in GitHub to change something in Terraform code, the Infracost pull request comment will be added when you go above your set threshold.
 8. To see the test pull request costs in Infracost Cloud, [log in](https://dashboard.infracost.io/) > switch to your organization > Projects. To learn more, see [our docs](https://www.infracost.io/docs/infracost_cloud/get_started/).
@@ -99,11 +104,14 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env vars into the container. Retrieve your Infracost API key by running `infracost configure get api_key`. We recommend using your same API key in all environments. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
+
   ```sh
   GITLAB_TOKEN=<your-gitlab-token>
   INFRACOST_API_KEY=<your-infracost-api-token>
   ```
+
 5. Add the following YAML spec to `repos.yaml` or `atlantis.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -117,7 +125,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               command: 'echo "/tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM-$WORKSPACE-${REPO_REL_DIR//\//-}-infracost.json"'
           # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
           #   complements the open source CLI by giving teams advanced visibility and controls.
-          #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+          #   The cost estimates are transmitted in JSON format and do not contain any cloud
           #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
           - env:
               name: INFRACOST_ENABLE_CLOUD
@@ -131,6 +139,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                   --format=json \
                                   --log-level=info \
                                   --out-file=$INFRACOST_OUTPUT
+                                  --project-name=$REPO_REL_DIR
           - run: |
               # Read the breakdown JSON and get costs using jq.
               # Note jq comes as standard as part of the infracost-atlantis Docker image. If you are using the base Atlantis
@@ -169,6 +178,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                        --gitlab-token $GITLAB_TOKEN \
                                        --behavior new
   ```
+
 6. Restart the Atlantis application with the new environment vars and config.
 7. Send a merge request in GitLab to change something in the Terraform code, the Infracost merge request comment will be added when you go above your set threshold.
 8. To see the test pull request costs in Infracost Cloud, [log in](https://dashboard.infracost.io/) > switch to your organization > Projects. To learn more, see [our docs](https://www.infracost.io/docs/infracost_cloud/get_started/).
@@ -182,12 +192,15 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
 2. If you haven't done so already, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
 3. Retrieve your Infracost API key by running `infracost configure get api_key`.
 4. You'll need to pass the following custom env vars into the container. Retrieve your Infracost API key by running `infracost configure get api_key`. We recommend using your same API key in all environments. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost auth login` to get a free API key.
+
   ```sh
   AZURE_ACCESS_TOKEN=<your-azure-devops-access-token-or-pat>
   AZURE_REPO_URL=<your-azure-repo-url> # i.e., https://dev.azure.com/your-org/your-project/_git/your-repo
   INFRACOST_API_KEY=<your-infracost-api-token>
   ```
+
 5. Add the following YAML spec to `repos.yaml` or `atlantis.yaml` config files:
+
   ```yaml
   repos:
     - id: /.*/
@@ -201,7 +214,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
               command: 'echo "/tmp/${BASE_REPO_OWNER//\//-}-$BASE_REPO_NAME-$PULL_NUM-$WORKSPACE-${REPO_REL_DIR//\//-}-infracost.json"'
           # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
           #   complements the open source CLI by giving teams advanced visibility and controls.
-          #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+          #   The cost estimates are transmitted in JSON format and do not contain any cloud
           #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
           - env:
               name: INFRACOST_ENABLE_CLOUD
@@ -215,6 +228,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                   --format=json \
                                   --log-level=info \
                                   --out-file=$INFRACOST_OUTPUT
+                                  --project-name=$REPO_REL_DIR
           - run: |
               # Read the breakdown JSON and get costs using jq.
               # Note jq comes as standard as part of the infracost-atlantis Docker image. If you are using the base Atlantis
@@ -253,6 +267,7 @@ For Bitbucket, see [our docs](https://www.infracost.io/docs/features/cli_command
                                             --azure-access-token $AZURE_ACCESS_TOKEN \
                                             --behavior new
   ```
+
 6. Restart the Atlantis application with the new environment vars and config.
 7. Send a pull request in Azure Repos to change something in Terraform code, the Infracost pull request comment will be added when you go above your set threshold.
 8. To see the test pull request costs in Infracost Cloud, [log in](https://dashboard.infracost.io/) > switch to your organization > Projects. To learn more, see [our docs](https://www.infracost.io/docs/infracost_cloud/get_started/).


### PR DESCRIPTION
Atlantis includes the variable REPO_REL_DIR in it's custom run command(https://www.runatlantis.io/docs/custom-workflows.html#custom-run-command), which is populated by the relative path to the project.

Setting this to the Infracost project name makes the output easier to read, turning something like:

`github.com/productboard/pb-infr...s-east-1/rds-psql/default.json`

into

`aws/pb-ops/us-east-1/rds-psql`


TODO:
Update screenshots with new output
