### PR TITLE
fix infracost file path for terragrunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If you use Atlantis with Terragrunt, you should:
           steps:
             - env:
                 name: INFRACOST_OUTPUT
-                command: 'echo "/tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM-$WORKSPACE-${REPO_REL_DIR//\//-}-infracost.json"'
+                command: 'echo "/tmp/$BASE_REPO_OWNER-$BASE_REPO_NAME-$PULL_NUM/$WORKSPACE-${REPO_REL_DIR//\//-}-infracost.json"'
             - env:
                 name: TERRAGRUNT_TFPATH
                 command: 'echo "terraform${ATLANTIS_TERRAFORM_VERSION}"'


### PR DESCRIPTION
It should be a folder for the whole PR to match other parts of the documenation where we are checking for the existance of a folder for the PR to send the comment, for example here: https://github.com/infracost/infracost-atlantis/blob/master/examples/combined-infracost-comment/README.md#running-with-github